### PR TITLE
Update auth group with link to GDoc

### DIFF
--- a/docs/community/source/community-groups/auth.rst
+++ b/docs/community/source/community-groups/auth.rst
@@ -5,4 +5,6 @@ Dataverse Authentication and Authorization Community Group
 
 The Dataverse Authentication and Authorization Community Group ("Auth" for short) reports on the state and future of authentication and authorization in installations of Dataverse to the :ref:`Dataverse Advisory Team <advisory-team>`. It is coordinated by `Philip Durbin <http://www.iq.harvard.edu/people/philip-durbin>`__ and `Ben Companjen <https://pure.knaw.nl/portal/en/persons/ben-companjen%280db8708d-9b7d-44f5-b960-521261d8b2f9%29.html>`__.
 
-Currently, people interested in auth are subscribed to the `dvn-auth <https://lists.iq.harvard.edu/pipermail/dvn-auth/2013-September/000000.html>`__ mailing list but different communication channels are being considered. Suggestions are welcome!
+At the group's first face-to-face meeting on June 10, 2015, we decided that people interested in auth should continue to use the `dvn-auth <https://lists.iq.harvard.edu/pipermail/dvn-auth/2013-September/000000.html>`__ mailing list, though different communication channels are still being considered. Suggestions are welcome!
+
+As the living documentation of the group's interests and activities we keep a `Dataverse Authentication and Authorization Community Group Google Doc <https://docs.google.com/document/d/1xbWkj_OIk13gKe7jleNXVvakZErvHLA8JRBvLz8Fe8Q/edit?usp=sharing>`__. Anyone can see and comment on this document - if you want to edit, please ask Phil or Ben.


### PR DESCRIPTION
After discussion with @pdurbin, we decided to use a Google Doc as the "website" with further links to documents and issues of interest.
